### PR TITLE
Fix vertical align in firefox

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,11 +33,11 @@ function generateBadgeSVG({
   <svg style="border-radius: ${borderRadius}px" viewBox="0 0 ${width} ${height}" width="${width}" xmlns="http://www.w3.org/2000/svg">
     <g>
       <rect x="0" y="0" width="${subjectLengt}" height="${height}" fill="${subjectColor}" />
-      <text font-size="${fontSize}px" font-weight="100" font-family="sans-serif" fill="${subjectTextColor}" x="${subjectLengt * 0.5}" y="55%" alignment-baseline="middle" text-anchor="middle">${subject}</text>
+      <text font-size="${fontSize}px" font-weight="100" font-family="sans-serif" fill="${subjectTextColor}" x="${subjectLengt * 0.5}" y="55%"  dominant-baseline="middle" text-anchor="middle">${subject}</text>
     </g>
     <g>
       <rect x="${subjectLengt}" y="0" width="${valueLength}" height="${height}" fill="${valueColor}" />
-      <text font-size="${fontSize}px" font-weight="100" font-family="sans-serif" fill="${valueTextColor}"  x="${width - (valueLength / 2)}" y="55%" alignment-baseline="middle" text-anchor="middle">${value}</text>
+      <text font-size="${fontSize}px" font-weight="100" font-family="sans-serif" fill="${valueTextColor}"  x="${width - (valueLength / 2)}" y="55%"   dominant-baseline="middle" text-anchor="middle">${value}</text>
     </g>
   </svg>
   `;


### PR DESCRIPTION
For vertical alignment of `<text>` nodes you need to use the `dominant-baseline.` attribute, as described in https://stackoverflow.com/a/15997503/128165